### PR TITLE
🔼 Bump to 1.2.119

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carrot-scan",
-  "version": "1.2.118",
+  "version": "1.2.119",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carrot-scan",
-      "version": "1.2.118",
+      "version": "1.2.119",
       "license": "MIT",
       "dependencies": {
         "@fastify/swagger": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carrot-scan",
-  "version": "1.2.118",
+  "version": "1.2.119",
   "description": "Command-line tool for detecting vulnerabilities in files and directories.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- Version bumped automatically  
- Lint/format fixes applied

## Usage

After every automatic bump, the workflow generates a convenience stub that matches the new version number.  
Import it and call it as shown below – just replace **X.Y.Z** with the package version you are using.

```js
import { featureX_Y_Z } from './src/feature-X.Y.Z.js';

featureX_Y_Z();
```

### Scanner API

The scanner now supports an **options** object.  
For instance:

```js
import { initScanner } from './scanner.js';

initScanner({
  verbose: true,
  concurrency: 4
});
```